### PR TITLE
Close the Socket after you're done with it, and use WSACleanup

### DIFF
--- a/Server/Server/Server.cpp
+++ b/Server/Server/Server.cpp
@@ -11,12 +11,12 @@ int main() {
     WORD wVersion = MAKEWORD(2, 2);
 
     wsa_startup_return_code = WSAStartup(wVersion, &wsaData);
-    if (wsa_startup_return_code != 0) {
+    if (wsa_startup_return_code == 0) {
         cout << "The Winsock dll found!" << endl;
         cout << "The status: " << wsaData.szSystemStatus << endl;
     }
     else {
-        cout << "The Winsock dll found!" << endl;
+        cout << "The Winsock dll not found!" << endl;
         return 0;
     }
 

--- a/Server/Server/Server.cpp
+++ b/Server/Server/Server.cpp
@@ -5,27 +5,38 @@
 using namespace std;
 
 int main() {
+    // Initialize WSA
     WSADATA wsaData;
     int wsa_startup_return_code;
     WORD wVersion = MAKEWORD(2, 2);
 
     wsa_startup_return_code = WSAStartup(wVersion, &wsaData);
     if (wsa_startup_return_code != 0) {
-        cout << "WSAStartup failed with error code: " << wsa_startup_return_code << endl;
-        return 1;
+        cout << "The Winsock dll found!" << endl;
+        cout << "The status: " << wsaData.szSystemStatus << endl;
+    }
+    else {
+        cout << "The Winsock dll found!" << endl;
+        return 0;
     }
 
+
+    // Create a socket
     SOCKET serverSocket, acceptSocket;
     serverSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (serverSocket == INVALID_SOCKET) {
         cout << "Error at socket(): " << WSAGetLastError() << endl;
         WSACleanup();
-        return 1;
+        return 0;
     }
+    cout << "socket() is OK!" << endl;
 
-    sockaddr_in service;
+
+    // Bind the socket with port
     int port = 55555;
+    sockaddr_in service;
     service.sin_family = AF_INET;
+    
     InetPton(AF_INET, L"127.0.0.1", &service.sin_addr.s_addr);
     service.sin_port = htons(port);
 
@@ -33,32 +44,35 @@ int main() {
         cout << "Binding failed: " << WSAGetLastError() << endl;
         closesocket(serverSocket);
         WSACleanup();
-        return 1;
+        return 0;
     }
+    cout << "bind() is OK!" << endl;
 
+
+    // Listen on the socket
     if (listen(serverSocket, 1) == SOCKET_ERROR) {
         cout << "Error listening on socket: " << WSAGetLastError() << endl;
         closesocket(serverSocket);
         WSACleanup();
-        return 1;
+        return 0;
     }
-
     cout << "Start listening on port: " << port << endl;
 
+    // Accept a connection
     acceptSocket = accept(serverSocket, NULL, NULL);
     if (acceptSocket == INVALID_SOCKET) {
         cout << "Accept failed: " << WSAGetLastError() << endl;
         closesocket(serverSocket);
         WSACleanup();
-        return 1;
+        return -1;
     }
-
     cout << "Accepted connection" << endl;
 
+    // Receive data
     char receiveBuffer[200] = "";
     int byteCount = recv(acceptSocket, receiveBuffer, 200, 0);
     if (byteCount < 0) {
-        cout << "Server error: " << WSAGetLastError() << endl;
+        cout << "Server error while receive message: " << WSAGetLastError() << endl;
     } else {
         cout << "Received data: " << receiveBuffer << endl;
     }


### PR DESCRIPTION
### Changes Made:

1.  **Proper Socket Closure:**
    
    -   Added calls to `closesocket` to close both the `serverSocket` and `acceptSocket` when they are no longer needed.
    -   This ensures that sockets are correctly closed and releases system resources, preventing potential resource leaks.
2.  **Winsock Cleanup:**
    
    -   Added a call to `WSACleanup` at the end of the program to clean up Winsock resources.
    -   This function call is crucial for releasing resources acquired during the Winsock initialization (WSAStartup).
    -   Failing to call `WSACleanup` can lead to resource leaks and potential issues when running the program multiple times.